### PR TITLE
Add invert binary tree solution and tests (LeetCode 226)

### DIFF
--- a/Top_Interview_150/Easy/invert_binary_tree.py
+++ b/Top_Interview_150/Easy/invert_binary_tree.py
@@ -1,0 +1,115 @@
+"""
+226. Invert Binary Tree
+Category: Binary Tree
+
+Intuition:
+To invert a binary tree means to swap every node’s left and right child.
+The simplest way to do this is recursion.
+For each node, swap its children, then do the same for its left and right subtrees.
+
+Approach:
+- If the node is None → return None.
+- Swap left and right children.
+- Recursively invert the left subtree.
+- Recursively invert the right subtree.
+- Return the root.
+
+Time Complexity:
+- O(n), where n is the number of nodes (we visit each node once).
+
+Space Complexity:
+- O(h) for recursion stack, where h is the height of the tree.
+  - O(log n) for balanced tree
+  - O(n) for skewed tree
+"""
+
+from typing import Optional
+from collections import deque
+
+
+class TreeNode:
+    def __init__(self, val=0, left=None, right=None):
+        self.val = val
+        self.left = left
+        self.right = right
+
+
+class Solution:
+    def invertTree(self, root: Optional[TreeNode]) -> Optional[TreeNode]:
+        if not root:
+            return None
+
+        # Swap children
+        root.left, root.right = root.right, root.left
+
+        # Recursively invert subtrees
+        self.invertTree(root.left)
+        self.invertTree(root.right)
+
+        return root
+
+
+def build_tree(nodes):
+    if not nodes:
+        return None
+
+    root = TreeNode(nodes[0])
+    queue = deque([root])
+    i = 1
+
+    while queue and i < len(nodes):
+        node = queue.popleft()
+
+        if i < len(nodes) and nodes[i] is not None:
+            node.left = TreeNode(nodes[i])
+            queue.append(node.left)
+        i += 1
+
+        if i < len(nodes) and nodes[i] is not None:
+            node.right = TreeNode(nodes[i])
+            queue.append(node.right)
+        i += 1
+
+    return root
+
+
+def tree_to_list(root):
+    if not root:
+        return []
+
+    result = []
+    queue = deque([root])
+
+    while queue:
+        node = queue.popleft()
+        if node:
+            result.append(node.val)
+            queue.append(node.left)
+            queue.append(node.right)
+        else:
+            result.append(None)
+
+    # Remove trailing None values
+    while result and result[-1] is None:
+        result.pop()
+
+    return result
+
+
+if __name__ == "__main__":
+    s = Solution()
+
+    # Example 1
+    root1 = build_tree([4, 2, 7, 1, 3, 6, 9])
+    inverted1 = s.invertTree(root1)
+    print(tree_to_list(inverted1))  # Expected: [4,7,2,9,6,3,1]
+
+    # Example 2
+    root2 = build_tree([2, 1, 3])
+    inverted2 = s.invertTree(root2)
+    print(tree_to_list(inverted2))  # Expected: [2,3,1]
+
+    # Example 3
+    root3 = build_tree([])
+    inverted3 = s.invertTree(root3)
+    print(tree_to_list(inverted3))  # Expected: []

--- a/Top_Interview_150/tests/test_226_invert_binary_tree.py
+++ b/Top_Interview_150/tests/test_226_invert_binary_tree.py
@@ -1,0 +1,120 @@
+import unittest
+import sys
+import os
+from typing import Optional
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from Easy.invert_binary_tree import Solution, TreeNode
+
+
+class TestInvertBinaryTree(unittest.TestCase):
+
+    def build_tree(self, vals):
+        if not vals:
+            return None
+        nodes = [TreeNode(val) if val is not None else None for val in vals]
+        kids = nodes[::-1]
+        root = kids.pop()
+        for node in nodes:
+            if node:
+                if kids: node.left = kids.pop()
+                if kids: node.right = kids.pop()
+        return root
+
+    def tree_to_list(self, root):
+        if not root:
+            return []
+
+        from collections import deque
+        result = []
+        queue = deque([root])
+
+        while queue:
+            node = queue.popleft()
+            if node:
+                result.append(node.val)
+                queue.append(node.left)
+                queue.append(node.right)
+            else:
+                result.append(None)
+
+        while result and result[-1] is None:
+            result.pop()
+
+        return result
+
+    # Official LeetCode Example 1
+    def test_case_1(self):
+        root = self.build_tree([4, 2, 7, 1, 3, 6, 9])
+        inverted = Solution().invertTree(root)
+        self.assertEqual(self.tree_to_list(inverted), [4, 7, 2, 9, 6, 3, 1])
+
+    # Official LeetCode Example 2
+    def test_case_2(self):
+        root = self.build_tree([2, 1, 3])
+        inverted = Solution().invertTree(root)
+        self.assertEqual(self.tree_to_list(inverted), [2, 3, 1])
+
+    # Official LeetCode Example 3
+    def test_case_3(self):
+        root = self.build_tree([])
+        inverted = Solution().invertTree(root)
+        self.assertEqual(self.tree_to_list(inverted), [])
+
+    # Single node
+    def test_case_4(self):
+        root = self.build_tree([1])
+        inverted = Solution().invertTree(root)
+        self.assertEqual(self.tree_to_list(inverted), [1])
+
+    # Two nodes (left only)
+    def test_case_5(self):
+        root = self.build_tree([1, 2])
+        inverted = Solution().invertTree(root)
+        self.assertEqual(self.tree_to_list(inverted), [1, None, 2])
+
+    # Two nodes (right only)
+    def test_case_6(self):
+        root = self.build_tree([1, None, 2])
+        inverted = Solution().invertTree(root)
+        self.assertEqual(self.tree_to_list(inverted), [1, 2])
+
+    # Left skewed tree
+    def test_case_7(self):
+        root = self.build_tree([1, 2, None, 3])
+        inverted = Solution().invertTree(root)
+        self.assertEqual(self.tree_to_list(inverted), [1, None, 2, None, 3])
+
+    # Right skewed tree
+    def test_case_8(self):
+        root = self.build_tree([1, None, 2, None, 3])
+        inverted = Solution().invertTree(root)
+        self.assertEqual(self.tree_to_list(inverted), [1, 2, None, 3])
+
+    # Negative values
+    def test_case_9(self):
+        root = self.build_tree([0, -1, -2])
+        inverted = Solution().invertTree(root)
+        self.assertEqual(self.tree_to_list(inverted), [0, -2, -1])
+
+    # Larger tree
+    def test_case_10(self):
+        root = self.build_tree([1,2,3,4,5,6,7,8,9])
+        inverted = Solution().invertTree(root)
+        self.assertEqual(
+            self.tree_to_list(inverted),
+            [1,3,2,7,6,5,4,None,None,None,None,None,None,9,8]
+        )
+
+    # Already symmetric structure (inverting gives same level-order)
+    def test_case_11(self):
+        root = self.build_tree([1,2,2,3,4,4,3])
+        inverted = Solution().invertTree(root)
+        self.assertEqual(
+            self.tree_to_list(inverted),
+            [1,2,2,3,4,4,3]  # symmetric tree: swap left/right yields same structure
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- Solution: recursive approach swapping left/right children at each node
- Time O(n), space O(h) for recursion stack
- 11 test cases covering: LeetCode examples, single node, skewed trees, negative values, larger tree, symmetric tree
- Fix test_case_11: for symmetric trees, inverting yields same structure (level-order unchanged), not reversed list

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a standalone algorithm implementation and unit tests; no changes to shared infrastructure or security/data-sensitive logic.
> 
> **Overview**
> Adds a new `Easy/invert_binary_tree.py` implementation for LeetCode 226 that recursively swaps left/right children to invert a binary tree, along with small helper utilities and a runnable example block.
> 
> Introduces `tests/test_226_invert_binary_tree.py` with 11 unit tests covering LeetCode examples and additional edge cases (empty/single node, skewed trees, negatives, larger trees, and symmetric-tree behavior).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 612ffe5232c42bb93b0f90d84550d511a04c1503. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->